### PR TITLE
fix: remove useless global img style

### DIFF
--- a/src/components/sswTvContactMap/contactUsMap/index.css
+++ b/src/components/sswTvContactMap/contactUsMap/index.css
@@ -1,9 +1,3 @@
-img {
-    vertical-align: middle;
-    max-width: 100%!important;
-    border: 0;
-}
-
 h6,
 .h6 {
     font-size: .75rem;


### PR DESCRIPTION
<!-- Include the issue it closes -->

<!-- Summarize your changes -->
We are using `<StaticImage>`, so we don't need this `img` style

<!-- include screenshots if relevant -->
