### PR TITLE
Reduced the carousel indicator transform size on hovering

### DIFF
--- a/src/components/indexPage/carousel/index.css
+++ b/src/components/indexPage/carousel/index.css
@@ -1,5 +1,5 @@
 .carousel-indicators [data-bs-target]:hover[data-bs-target]:hover{
-    transform: scale(1.5);
+    transform: scale(1.2);
     transition-property: all;
     transition-property: transform;
     transition-timing-function: ease;


### PR DESCRIPTION
<!-- Include the issue it closes -->
#41
<!-- Summarize your changes -->

- Reduce carousel indicators size while hovering

<!-- include screenshots if relevant -->
![2022-02-02_17-09-52](https://user-images.githubusercontent.com/96504411/152102815-54383298-4905-4d71-9633-7ab2475fd1dc.gif)

