### PR TITLE
Refactor html in contact us and add increased contrast on consulting

### DIFF
--- a/src/components/indexPage/consultingServices/index.css
+++ b/src/components/indexPage/consultingServices/index.css
@@ -108,7 +108,7 @@
 }
 
 #whatwedo .do-angular a:hover {
-    background-color: #d83535;
+    background-color: #d76969;
 }
 
 #whatwedo .do-cloud a {
@@ -117,7 +117,7 @@
 }
 
 #whatwedo .do-cloud a:hover {
-    background-color: #ababab;
+    background-color: #b8b8b8;
 }
 
 #whatwedo .do-mobile a {
@@ -126,7 +126,7 @@
 }
 
 #whatwedo .do-mobile a:hover {
-    background-color: #737373;
+    background-color: #808080;
 }
 
 #whatwedo .do-rules a {
@@ -135,7 +135,7 @@
 }
 
 #whatwedo .do-rules a:hover {
-    background-color: #4e4e4e;
+    background-color: #5a5a5a;
 }
 
 @media (min-width: 992px) {

--- a/src/components/sswTvContactMap/contactUsMap/index.tsx
+++ b/src/components/sswTvContactMap/contactUsMap/index.tsx
@@ -66,8 +66,6 @@ const Map = ({ hoverStyle }) => {
 const ContactUs = ({ toggleHover }) => {
   const [activeLocation, setActiveLocation] = useState(ACTIVE_KEYS.Sydney);
   //Office Open Time Logic
-  dayjs.extend(timezone);
-  dayjs.extend(utc);
   const [currentTime, setCurrentTime] = useState(
     dayjs().tz(TIME_ZONE_KEYS.NSW)
   );

--- a/src/components/sswTvContactMap/contactUsMap/index.tsx
+++ b/src/components/sswTvContactMap/contactUsMap/index.tsx
@@ -2,33 +2,33 @@ import React, { useState } from "react";
 import { Accordion } from "react-bootstrap";
 import { StaticImage } from "gatsby-plugin-image";
 import dayjs from "dayjs";
-import timezone from 'dayjs/plugin/timezone';
-import utc from 'dayjs/plugin/utc';
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import "./index.css";
 
 dayjs.extend(timezone);
 dayjs.extend(utc);
 
 const ACTIVE_KEYS = {
-  Sydney: 'Sydney',
-  Brisbane: 'Brisbane',
-  Melbourne: 'Melbourne',
-  Newcastle: 'Newcastle',
-  None: '',
+  Sydney: "Sydney",
+  Brisbane: "Brisbane",
+  Melbourne: "Melbourne",
+  Newcastle: "Newcastle",
+  None: "",
 };
 
 const ACCORDIONS = {
-  NSW: 'active-accordion-nsw',
-  QLD: 'active-accordion-qld',
-  VIC: 'active-accordion-vic',
-  Newcastle: 'active-accordion-newcastle',
-  None: '',
+  NSW: "active-accordion-nsw",
+  QLD: "active-accordion-qld",
+  VIC: "active-accordion-vic",
+  Newcastle: "active-accordion-newcastle",
+  None: "",
 };
 
 const WORKING_TIME = {
-  Open: 6,
+  Open: 9,
   Close: 18,
-}
+};
 
 const DAY_KEYS = {
   Sunday: 0,
@@ -41,9 +41,9 @@ const DAY_KEYS = {
 };
 
 const TIME_ZONE_KEYS = {
-  QLD: 'Australia/Queensland',
-  NSW: 'Australia/NSW',
-  VIC: 'Australia/Victoria',
+  QLD: "Australia/Queensland",
+  NSW: "Australia/NSW",
+  VIC: "Australia/Victoria",
 };
 
 const Map = ({ hoverStyle }) => {
@@ -64,13 +64,13 @@ const Map = ({ hoverStyle }) => {
   );
 };
 const ContactUs = ({ toggleHover }) => {
-  const [activeLocation, setActiveLocation] = useState(
-    ACTIVE_KEYS.Sydney
-  );
+  const [activeLocation, setActiveLocation] = useState(ACTIVE_KEYS.Sydney);
   //Office Open Time Logic
   dayjs.extend(timezone);
   dayjs.extend(utc);
-  const [currentTime, setCurrentTime] = useState(dayjs().tz(TIME_ZONE_KEYS.NSW));
+  const [currentTime, setCurrentTime] = useState(
+    dayjs().tz(TIME_ZONE_KEYS.NSW)
+  );
   let time: any;
   if (
     dayjs().day() != DAY_KEYS.Sunday &&
@@ -133,7 +133,7 @@ const ContactUs = ({ toggleHover }) => {
                   <br />
                   Neutral Bay, <span itemProp="addressLocality">
                     Sydney
-                  </span>, <span itemProp="addressRegion">NSW</span>
+                  </span>, <span itemProp="addressRegion">NSW&nbsp;</span>
                   <span itemProp="postalCode">2089</span>,{" "}
                   <span itemProp="addressCountry">Australia</span>
                 </p>
@@ -198,8 +198,8 @@ const ContactUs = ({ toggleHover }) => {
                     Level 1, 471 Adelaide Street
                   </span>
                   <br />
-                  <span itemProp="addressLocality"> Brisbane</span>,{" "}
-                  <span itemProp="addressRegion">QLD</span>
+                  <span itemProp="addressLocality"> Brisbane&nbsp;</span>,{" "}
+                  <span itemProp="addressRegion">QLD </span>
                   <span itemProp="postalCode"> 4000</span>,
                   <span itemProp="addressCountry">Australia</span>
                 </p>
@@ -264,8 +264,8 @@ const ContactUs = ({ toggleHover }) => {
                     Level 1, 370 Little Bourke Street
                   </span>
                   <br />
-                  <span itemProp="addressLocality">Melbourne</span>,
-                  <span itemProp="addressRegion">VIC</span>
+                  <span itemProp="addressLocality">Melbourne&nbsp;</span>,
+                  <span itemProp="addressRegion">VIC </span>
                   <span itemProp="postalCode">3000</span>,
                   <span itemProp="addressCountry">Australia</span>
                 </p>


### PR DESCRIPTION
<!-- Include the issue it closes -->
Resolves #112 
<!-- Summarize your changes -->

- Added space between states name and postcode in contact us accordion.
- Added new hovering images with increased contrast in consulting services.

<!-- include screenshots if relevant -->
![image](https://user-images.githubusercontent.com/96504411/154174269-a5e4cebc-1c97-4c5d-b400-b04840c33a24.png)
**Figure: Added space between states and postcode on contact us accordion**

![gif pr](https://user-images.githubusercontent.com/96504411/154174470-2851e727-f0b6-4309-b03b-b6b20cb01e74.gif)
**Figure: Added hovering effect with increased contrast of 10 percent on consulting services**
