### PR TITLE
fix .css module import issue in components

### DIFF
--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -1,0 +1,4 @@
+// This script fixes the issue:
+//  "Cannot find module '*.css' or its corresponding type declarations.ts(2307)"
+
+declare module '*.css';


### PR DESCRIPTION
<!-- Include the issue it closes -->
#221 
<!-- Summarize your changes -->
fixed the issue "Cannot find module '*.css' or its corresponding type declarations.ts(2307)" when importing `*.module.css` in `src/components/*.tsx` files
<!-- include screenshots if relevant -->
![177900923-05b2f2e5-bb5b-4bfe-abf2-f1ab81752eba](https://user-images.githubusercontent.com/41563445/177918753-78a417fa-6b36-47a2-9aeb-2ce90bbe2116.png)

