### PR TITLE
added tag needed due to SysAdmin policy changes

### DIFF
--- a/.azure/create-storage.bicep
+++ b/.azure/create-storage.bicep
@@ -9,6 +9,9 @@ var storageAccountName = '${appName}storage'
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   name: storageAccountName
   location: location
+  tags: {
+    'cost-category': 'dev/test'
+  }
   sku: {
     name: storageSKU
   }


### PR DESCRIPTION
SysAdmins have made a policy change requiring a `cost-category` tag.
Quick fix made to unblock @Geordie88 so he can deploy new 404 page for testing.

An issue #242 has been added to fix this properly later.
