### PR TITLE
🐛Typo - misspelled 'maximum'

### DIFF
--- a/src/components/bookingForm/index.tsx
+++ b/src/components/bookingForm/index.tsx
@@ -282,7 +282,7 @@ const BookingForm = ({ isShareForm }) => {
                 handleInput(ACTIVE_INPUT.Note, e.currentTarget.value);
               }}
             />
-            <small>Maximium 2000 characters</small>
+            <small>Maximum 2000 characters</small>
             <Form.Control.Feedback type="invalid">
               Please provide note.
             </Form.Control.Feedback>

--- a/src/components/bookingFormFormik/formGroupTextArea/index.tsx
+++ b/src/components/bookingFormFormik/formGroupTextArea/index.tsx
@@ -25,7 +25,7 @@ const FormGroupTextArea = ({
           isValid={isValid}
           isInvalid={!!isErrors}
         />
-        <small>Maximium 2000 characters</small>
+        <small>Maximum 2000 characters</small>
         <Form.Control.Feedback type="valid">
           {VALIDATION_SUCCESS_MESSAGE}
         </Form.Control.Feedback>


### PR DESCRIPTION
<!-- Include the issue it closes -->

<!-- Summarize your changes -->
fix a typo

change text from
    maximium  
    to  
    maximum  
<!-- include screenshots if relevant -->
